### PR TITLE
fix navigation scroll targets

### DIFF
--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -1,11 +1,11 @@
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Heart, Users, Globe, Target, ArrowDown } from "lucide-react";
-import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious } from "@/components/ui/carousel";
+import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious, type CarouselApi } from "@/components/ui/carousel";
 import { useState, useEffect } from "react";
 const AboutSection = () => {
   const [currentSlide, setCurrentSlide] = useState(0);
-  const [carouselApi, setCarouselApi] = useState<any>();
+  const [carouselApi, setCarouselApi] = useState<CarouselApi | null>(null);
   useEffect(() => {
     if (!carouselApi) {
       return;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -37,13 +37,10 @@ const Header = () => {
     return () => window.removeEventListener('scroll', checkHeaderPosition);
   }, []);
   const scrollToSection = (id: string) => {
-    console.log('Scrolling to section:', id);
     const element = document.getElementById(id);
-    console.log('Element found:', element);
     if (element) {
       const headerHeight = 80;
-      const elementPosition = element.offsetTop - headerHeight;
-      console.log('Scrolling to position:', elementPosition);
+      const elementPosition = element.getBoundingClientRect().top + window.pageYOffset - headerHeight;
       window.scrollTo({
         top: elementPosition,
         behavior: 'smooth'

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -22,13 +22,10 @@ const HeroSection = () => {
     return () => clearInterval(interval);
   }, []);
   const scrollToSection = (id: string) => {
-    console.log('Hero scrolling to section:', id);
     const element = document.getElementById(id);
-    console.log('Hero element found:', element);
     if (element) {
       const headerHeight = 80;
-      const elementPosition = element.offsetTop - headerHeight;
-      console.log('Hero scrolling to position:', elementPosition);
+      const elementPosition = element.getBoundingClientRect().top + window.pageYOffset - headerHeight;
       window.scrollTo({
         top: elementPosition,
         behavior: 'smooth'

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -125,5 +126,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- ensure header and hero buttons scroll to their intended sections instead of the hero carousel
- replace any and CommonJS require usage flagged by lint

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4cb808fc88328bd3bf5369cd9e186